### PR TITLE
Reduce linux socket::connect() timeout down to 10 secs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "qualisys_cpp_sdk"]
 	path = qualisys_cpp_sdk
-	url = https://github.com/qualisys/qualisys_cpp_sdk.git
+	url = https://github.com/tiiuae/qualisys_cpp_sdk

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mocap_pose
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* 0.1.1 : Reduce linux socket::connect() timeout down to 10 sec
+* 0.1.0 : extra loop to reset local CRTProtocol structure, if wasn't successful receive for 10 sec
 
 Forthcoming
 -----------
@@ -12,5 +14,4 @@ Forthcoming
 * Adding debian pkg stuff + other small fixes
 * Initial Commit for mocap_pose
 * add qualisys submodule
-* first commit
 * Contributors: Sergey Smirnov

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mocap_pose</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>Converts Qualisys Mocap pose into ROS2 / PX4 GPS message</description>
   <maintainer email="sergey.smirnov@unikie.com">Sergey Smirnov</maintainer>
   <license>BSD</license>


### PR DESCRIPTION
Converting to our local fork of qualisys_сpp_sdk, where socket timeout issue is fixed

Here is "the core" change for this PR: 

https://github.com/tiiuae/qualisys_cpp_sdk/commit/403ff978ecf2d7db32cb5b02727686050da7def1