### PR TITLE
Add SIGTERM handler which is converted to SIGINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,9 @@ RUN /packaging/build.sh
 
 FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-2f516bb
 
-ENTRYPOINT exec ros-with-env ros2 launch mocap_pose mocap_pose.launch \
-	address:=$INDOOR_SERVER_IP_ADDRESS \
-	lat:=$INDOOR_ORIGO_LATITUDE \
-	lon:=$INDOOR_ORIGO_LONGITUDE \
-	alt:=$INDOOR_ORIGO_ALTITUDE
+ENTRYPOINT [ "/entrypoint.sh" ]
+
+COPY entrypoint.sh /entrypoint.sh
 
 COPY --from=builder /main_ws/ros-*-mocap-pose_*_amd64.deb /mocap-pose.deb
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 _term() {
     # FILL UP PROCESS SEARCH PATTERN HERE TO FIND PROPER PROCESS FOR SIGINT:
@@ -25,11 +25,14 @@ ros-with-env ros2 launch mocap_pose mocap_pose.launch \
 child=$!
 
 echo "Waiting for pid $child"
-# Calling "wait" will then wait for the job with the specified by $child to finish, or for any signals to be fired.
-# Due to "or for any signals to be fired", "wait" will also handle SIGTERM and it will shutdown before
-# the node ends gracefully.
-# The solution is to add a second "wait" call and remove the trap between the two calls.
+# * Calling "wait" will then wait for the job with the specified by $child to finish, or for any signals to be fired.
+#   Due to "or for any signals to be fired", "wait" will also handle SIGTERM and it will shutdown before
+#   the node ends gracefully.
+#   The solution is to add a second "wait" call and remove the trap between the two calls.
+# * Do not use -e flag in the first wait call because wait will exit with error after catching SIGTERM.
+set +e
 wait $child
+set -e
 trap - TERM
 wait $child
 RESULT=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+_term() {
+    # FILL UP PROCESS SEARCH PATTERN HERE TO FIND PROPER PROCESS FOR SIGINT:
+    pattern="mocap_pose/mocap_pose_node"
+
+    pid_value="$(ps -ax | grep $pattern | grep -v grep | awk '{ print $1 }')"
+    if [ "$pid_value" != "" ]; then
+        pid=$pid_value
+        echo "Send SIGINT to pid $pid"
+    else
+        pid=1
+        echo "Pattern not found, send SIGINT to pid $pid"
+    fi
+    kill -s SIGINT $pid
+}
+trap _term SIGTERM
+
+ros-with-env ros2 launch mocap_pose mocap_pose.launch \
+    address:=$INDOOR_SERVER_IP_ADDRESS \
+    lat:=$INDOOR_ORIGO_LATITUDE \
+    lon:=$INDOOR_ORIGO_LONGITUDE \
+    alt:=$INDOOR_ORIGO_ALTITUDE &
+child=$!
+
+echo "Waiting for pid $child"
+wait $child
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+    echo "ERROR: Mocap pose node failed with code $RESULT" >&2
+    exit $RESULT
+else
+    echo "INFO: Mocap pose node finished successfully, but returning 125 code for docker to restart properly." >&2
+    exit 125
+fi


### PR DESCRIPTION
Entrypoint receives SIGTERM (from docker stop) and sends SIGINT to proper process to make ROS2 node to stop gracefully.
This prevents SROS authentication from breaking due to uncontrolled termination of the ROS2 node.