### PR TITLE
Bump tiiuae/fog-ros-baseimage from v1.0.0 to v2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v1.0.0 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:dp-4266_humble_upgrade AS builder
 
 COPY . /main_ws/src/
 
@@ -11,7 +11,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v1.0.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:dp-4266_humble_upgrade
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:dp-4266_humble_upgrade AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v2.0.0 AS builder
 
 COPY . /main_ws/src/
 
@@ -11,7 +11,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:dp-4266_humble_upgrade
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v2.0.0
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 


### PR DESCRIPTION
Update fog-ros-baseimage from dp-4266_humble_upgrade to v2.0.0
This PR is auto generated by a remote workflow.
Message from author of this PR;
**This PR is now ready for merge.**
