### PR TITLE
Bump baseimage from v3.0.1 to v3.0.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      baseimage-dependencies:
+          patterns:
+            - "tiiuae/fog-ros-sdk"
+            - "tiiuae/fog-ros-baseimage-builder"
+            - "tiiuae/fog-ros-baseimage"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.1-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-79529bc-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -14,7 +14,11 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.1
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-79529bc
+
+HEALTHCHECK --interval=5s \
+	CMD fog-health check --metric=location_update_count --diff-gte=5.0 \
+		--metrics-from=http://localhost:${METRICS_PORT}/metrics --only-if-nonempty=${METRICS_PORT}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-79529bc-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.2-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -14,7 +14,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-79529bc
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.2
 
 HEALTHCHECK --interval=5s \
 	CMD fog-health check --metric=location_update_count --diff-gte=5.0 \


### PR DESCRIPTION
Update fog-ros-baseimage from v3.0.1 to v3.0.2