### PR TITLE
Use pkcs11-closer to remove sessions references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
+FROM ghcr.io/tiiuae/pkcs11-closer:sha-7bec028 AS closer
+
 FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.2.0
 
 HEALTHCHECK --interval=5s \
@@ -29,4 +31,5 @@ COPY entrypoint.sh /entrypoint.sh
 # See: https://github.com/tiiuae/fog-ros-baseimage/blob/main/Dockerfile
 WORKDIR $WORKSPACE_DIR
 
+COPY --from=closer /pkcs11-closer /
 COPY --from=builder $WORKSPACE_DIR/install install

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,8 @@ trap - TERM
 wait $child
 RESULT=$?
 
+/pkcs11-closer --label mocap-pose
+
 if [ $RESULT -ne 0 ]; then
     echo "ERROR: Mocap pose node failed with code $RESULT" >&2
     exit $RESULT


### PR DESCRIPTION
Pkcs11-closer is an utility application which closes PKCS#11 sessions which may have been left behind due to some erratic behaviour. This should fix the issue reported in [DP-9022](https://ssrc.atlassian.net/browse/DP-9022).