### PR TITLE
Update ros-baseimage version to sha-c66a922

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.2.0-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-c66a922-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -16,7 +16,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 
 FROM ghcr.io/tiiuae/pkcs11-closer:sha-7bec028 AS closer
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.2.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-c66a922
 
 HEALTHCHECK --interval=5s \
 	CMD fog-health check --metric=location_update_count --diff-gte=5.0 \


### PR DESCRIPTION
This pull request updates the ros-baseimage version to sha-c66a922.